### PR TITLE
Allow disqus_api.yml to embed values with ERB

### DIFF
--- a/lib/disqus_api/railtie.rb
+++ b/lib/disqus_api/railtie.rb
@@ -4,7 +4,7 @@ module DisqusApi
       config_path = File.join(Rails.root, 'config', "disqus_api.yml")
 
       if File.exist?(config_path)
-        DisqusApi.config = YAML.load_file(File.join(Rails.root, 'config', "disqus_api.yml"))[Rails.env]
+        DisqusApi.config = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', "disqus_api.yml"))).result)[Rails.env]
       else
         unless Rails.env.test?
           puts "WARNING: No config/disqus_api.yml provided for Disqus API. Make sure to set configuration manually."


### PR DESCRIPTION
Not sure if you've intentionally omitted this feature - if so I'd be interested to know why (it feels more secure to at least have the option to put the secret keys in ENV variables that we then interpret from the YAML, though from reading a couple of blog posts I get the impression there's little agreement on this).