### PR TITLE
Allow embedding ruby in YAML config

### DIFF
--- a/lib/disqus_api/railtie.rb
+++ b/lib/disqus_api/railtie.rb
@@ -4,7 +4,9 @@ module DisqusApi
       config_path = File.join(Rails.root, 'config', "disqus_api.yml")
 
       if File.exist?(config_path)
-        DisqusApi.config = YAML.load_file(File.join(Rails.root, 'config', "disqus_api.yml"))[Rails.env]
+        DisqusApi.config = YAML.safe_load(ERB.new(
+          File.read(Rails.root.join("config", "disqus_api.yml"))
+        ).result)[Rails.env]
       else
         unless Rails.env.test?
           puts "WARNING: No config/disqus_api.yml provided for Disqus API. Make sure to set configuration manually."


### PR DESCRIPTION
Just a simple patch. Title says it all.

If you want me to change formatting, I can do that in a jiffy. (Considering the config line is 116 characters I broke it off into three lines)

cc @einzige

btw the CI job is failing due to ActiveSupport 5.0 requiring at least Ruby 2.2.2. See https://github.com/toptal/disqus_api/blob/master/disqus_api.gemspec#L22