### PR TITLE
Fix ActiveSupport dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - "1.9.3"

--- a/disqus_api.gemspec
+++ b/disqus_api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.description = %q{Provides clean Disqus API for your Ruby app with a nice interface.}
   s.summary = %q{Disqus API for Ruby}
 
-  s.add_runtime_dependency 'activesupport', ">= 3.0.0"
+  s.add_runtime_dependency 'activesupport', ">= 3.0.0", "< 5"
   s.add_runtime_dependency 'faraday', "~> 0.9.2"
   s.add_runtime_dependency 'faraday_middleware', "~> 0.10.0"
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
The change sets the version of ActiveSupport required to be less than 5, this allows more ruby versions to support the gem.

cc @einzige 

This should be really straightforward. It should fix the failing builds and allow more ruby versions to support the gem.

Can you please tag the new version and bump the RubyGems release?