### PR TITLE
Allow aliases in YAML config

### DIFF
--- a/lib/disqus_api/railtie.rb
+++ b/lib/disqus_api/railtie.rb
@@ -1,12 +1,10 @@
 module DisqusApi
   class Railtie < Rails::Railtie
     initializer 'disqus_api.initialize' do
-      config_path = File.join(Rails.root, 'config', "disqus_api.yml")
+      config_path = Rails.root.join('config', 'disqus_api.yml')
 
-      if File.exist?(config_path)
-        DisqusApi.config = YAML.safe_load(ERB.new(
-          File.read(Rails.root.join("config", "disqus_api.yml"))
-        ).result)[Rails.env]
+      if config_path.exist?
+        DisqusApi.config = YAML.load(ERB.new(config_path.read).result)[Rails.env]
       else
         unless Rails.env.test?
           puts "WARNING: No config/disqus_api.yml provided for Disqus API. Make sure to set configuration manually."


### PR DESCRIPTION
Support referencing repeated nodes with aliases, which is disallowed by `YAML.safe_load`. The typical use case for this is sharing configuration settings across environments.