### PR TITLE
Add support for Faraday 1.x

### DIFF
--- a/disqus_api.gemspec
+++ b/disqus_api.gemspec
@@ -20,10 +20,9 @@ Gem::Specification.new do |s|
   s.summary = %q{Disqus API for Ruby}
 
   s.add_runtime_dependency 'activesupport'
-  s.add_runtime_dependency 'faraday', '~> 0.9'
-  s.add_runtime_dependency 'faraday_middleware', '~> 0.10'
+  s.add_runtime_dependency 'faraday', '>= 0.9', '< 2.0'
+  s.add_runtime_dependency 'faraday_middleware', '>= 0.10', '< 2.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'rake'
 end
-


### PR DESCRIPTION
Migration to Sentry requires Faraday 1.x usage.
We have to allow Faraday 1.x for DisqusAPI in order to resolve dependencies.